### PR TITLE
Fix PHP "Access Level" Error

### DIFF
--- a/src/Html/AttributesTrait.php
+++ b/src/Html/AttributesTrait.php
@@ -97,7 +97,7 @@ trait AttributesTrait {
    *   The string of all attributes, starting with a space.
    *   E.g. ' class="class0 class1" id="5"'
    */
-  protected function renderAttributes() {
+  public function renderAttributes() {
     $attributes = $this->attributes;
     if (!empty($this->classes)) {
       $attributes['class'] = implode(' ', $this->classes);
@@ -115,7 +115,7 @@ trait AttributesTrait {
    *
    * @return string
    */
-  protected function renderTag($tagName, $content) {
+  public function renderTag($tagName, $content) {
     return '<' . $tagName . $this->renderAttributes() . '>' . $content . '</' . $tagName . '>';
   }
 
@@ -124,7 +124,7 @@ trait AttributesTrait {
    *
    * @return TagInterface
    */
-  protected function createTag($tagName) {
+  public function createTag($tagName) {
     $tag = new Tag($tagName);
     $tag->attributes = $this->attributes;
     $tag->classes = $this->classes;

--- a/src/Html/MutableAttributesTrait.php
+++ b/src/Html/MutableAttributesTrait.php
@@ -42,7 +42,7 @@ trait MutableAttributesTrait {
    *   The string of all attributes, starting with a space.
    *   E.g. ' class="class0 class1" id="5"'
    */
-  protected function renderAttributes() {
+  public function renderAttributes() {
     return $this->attributes->renderAttributes();
   }
 
@@ -52,7 +52,7 @@ trait MutableAttributesTrait {
    *
    * @return string
    */
-  protected function renderTag($tagName, $content) {
+  public function renderTag($tagName, $content) {
     return $this->attributes->renderTag($tagName, $content);
   }
 
@@ -61,7 +61,7 @@ trait MutableAttributesTrait {
    *
    * @return TagInterface
    */
-  protected function createTag($tagName) {
+  public function createTag($tagName) {
     return $this->attributes->createTag($tagName);
   }
 


### PR DESCRIPTION
By @validoll from [donquixote/cellbrush#1](https://github.com/donquixote/cellbrush/issues/1)

> Access level to Donquixote\Cellbrush\Table\Table::renderAttributes() must be public (as in class Donquixote\Cellbrush\Html\AttributesGetterInterface) in vendor/donquixote/cellbrush/src/Table/Table.php on line 111
